### PR TITLE
Add simple deepfake model loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # Deepshield
+
+This repository demonstrates a minimal setup for experimenting with deepfake detection models. The `deepfake_model.py` module implements **Step 3** of the pipeline: loading a pretrained detection model. If no model is available, a random predictor is used instead.

--- a/deepfake_model.py
+++ b/deepfake_model.py
@@ -1,0 +1,36 @@
+import os
+import random
+
+try:
+    import torch
+    from torch import nn
+except ImportError:  # torch not installed
+    torch = None
+    nn = None
+
+class RandomDeepfakeModel:
+    """Fallback model that randomly predicts real (0) or fake (1)."""
+
+    def predict(self, image):
+        return random.randint(0, 1)
+
+
+def load_deepfake_model(model_path=None):
+    """Load a pretrained deepfake detection model.
+
+    Attempts to load a model from ``model_path`` using PyTorch. When that
+    isn't possible (for example, PyTorch isn't installed or the weights
+    are missing), this function returns a :class:`RandomDeepfakeModel` that
+    simply returns a random prediction.
+    """
+    if torch is None:
+        return RandomDeepfakeModel()
+
+    if model_path and os.path.exists(model_path):
+        try:
+            model = torch.load(model_path, map_location="cpu")
+            model.eval()
+            return model
+        except Exception:
+            pass
+    return RandomDeepfakeModel()


### PR DESCRIPTION
## Summary
- implement deepfake model loading with fallback random predictor
- document the new module

## Testing
- `python3 -m py_compile deepfake_model.py`
- `python3 - <<'PY'
import deepfake_model
model = deepfake_model.load_deepfake_model()
print('Prediction:', model.predict(None))
PY`

------
https://chatgpt.com/codex/tasks/task_e_6883e20edce083219d0cf1295d1ce10a